### PR TITLE
Make package publishable via NPM

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,7 +12,7 @@
 	
 	<target name="-purgeJsDeploy">
 		<delete>
-			<fileset dir="${dist.dir}" includes="${dist.name} ${dist.min.name} ${dist.amd.name}" />
+			<fileset dir="${dist.dir}" includes="${dist.name} ${dist.min.name} ${dist.amd.name} ${dist.cjs.name}" />
 		</delete>
 	</target>
 	
@@ -32,9 +32,12 @@
 		
 		<copy file="${src.dir}/wrapper_closure.js" tofile="${dist.dir}/${dist.name}" />	
 		<copy file="${src.dir}/wrapper_amd.js" tofile="${dist.dir}/${dist.amd.name}" />
+		<copy file="${src.dir}/wrapper_cjs.js" tofile="${dist.dir}/${dist.cjs.name}" />
+		<copy file="${src.dir}/package.json" tofile="package.json" />
 		
 		<replace>
-			<fileset dir="${dist.dir}" includes="${dist.name} ${dist.amd.name}" />
+			<fileset dir="${dist.dir}" includes="${dist.name} ${dist.amd.name} ${dist.cjs.name}" />
+            <fileset dir="." includes="package.json" />
 			<replacefilter token="//::LICENSE:://" value="${license.txt}" />
 			<replacefilter token="//::SIGNALS_JS:://" value="${signals.js}" />
 			<replacefilter token="//::SIGNAL_BINDING_JS:://" value="${SignalBinding.js}" />

--- a/dev/build/build.properties
+++ b/dev/build/build.properties
@@ -16,4 +16,5 @@ dist.name = ${product.name}.js
 dist.amd.name = ${product.name}.amd.js
 dist.min.name = ${product.name}.min.js
 dist.inst.name = ${product.name}.inst.js
+dist.cjs.name = ${product.name}.cjs.js
 coverage.json = ${coverage.dir}/coverage.json

--- a/dev/src/package.json
+++ b/dev/src/package.json
@@ -1,0 +1,13 @@
+{
+    "name"        : "js-signals",
+    "main"        : "dist/js-signals.cjs.js",
+    "description" : "Custom Event/Messaging system for JavaScript inspired by AS3-Signals",
+    "version"     : "::VERSION_NUMBER::",
+    "author"      : "Miller Medeiros (http://blog.millermedeiros.com/)",
+    "repository"  : {
+        "type"    : "git",
+        "url"     : "https://github.com/millermedeiros/js-signals.git"
+    },
+    "homepage"    : "http://millermedeiros.github.com/js-signals/"
+}
+

--- a/dev/src/wrapper_cjs.js
+++ b/dev/src/wrapper_cjs.js
@@ -1,0 +1,13 @@
+/*jslint onevar:true, undef:true, newcap:true, regexp:true, bitwise:true, maxerr:50, indent:4, white:false, nomen:false, plusplus:false */
+/*global module:false*/
+
+//::LICENSE:://
+
+//::SIGNALS_JS:://
+
+//::SIGNAL_BINDING_JS:://
+
+//::SIGNAL_JS:://
+
+module.exports = signals;
+

--- a/dist/js-signals.cjs.js
+++ b/dist/js-signals.cjs.js
@@ -1,0 +1,354 @@
+/*jslint onevar:true, undef:true, newcap:true, regexp:true, bitwise:true, maxerr:50, indent:4, white:false, nomen:false, plusplus:false */
+/*global exports:false*/
+
+/*!!
+ * JS Signals <http://millermedeiros.github.com/js-signals/>
+ * Released under the MIT license <http://www.opensource.org/licenses/mit-license.php>
+ * @author Miller Medeiros <http://millermedeiros.com/>
+ * @version 0.6
+ * @build 181 (05/01/2011 01:47 PM)
+ */
+
+	/**
+	 * @namespace Signals Namespace - Custom event/messaging system based on AS3 Signals
+	 * @name signals
+	 */
+	var signals = /** @lends signals */{
+		/**
+		 * Signals Version Number
+		 * @type String
+		 * @const
+		 */
+		VERSION : '0.6'
+	};
+
+	// SignalBinding -------------------------------------------------
+	//================================================================
+	
+	/**
+	 * Object that represents a binding between a Signal and a listener function.
+	 * <br />- <strong>This is an internal constructor and shouldn't be called by regular users.</strong>
+	 * <br />- inspired by Joa Ebert AS3 SignalBinding and Robert Penner's Slot classes.
+	 * @author Miller Medeiros
+	 * @constructor
+	 * @internal
+	 * @name signals.SignalBinding
+	 * @param {signals.Signal} signal	Reference to Signal object that listener is currently bound to.
+	 * @param {Function} listener	Handler function bound to the signal.
+	 * @param {boolean} isOnce	If binding should be executed just once.
+	 * @param {Object} [listenerContext]	Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+	 * @param {Number} [priority]	The priority level of the event listener. (default = 0).
+	 */
+	 function SignalBinding(signal, listener, isOnce, listenerContext, priority){
+		
+		/**
+		 * Handler function bound to the signal.
+		 * @type Function
+		 * @private
+		 */
+		this._listener = listener;
+		
+		/**
+		 * If binding should be executed just once.
+		 * @type boolean
+		 * @private
+		 */
+		this._isOnce = isOnce;
+		
+		/**
+		 * Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+		 * @memberOf signals.SignalBinding.prototype
+		 * @name context
+		 * @type Object|undefined|null
+		 */
+		this.context = listenerContext;
+		
+		/**
+		 * Reference to Signal object that listener is currently bound to.
+		 * @type signals.Signal
+		 * @private
+		 */
+		this._signal = signal;
+		
+		/**
+		 * Listener priority
+		 * @type Number
+		 * @private
+		 */
+		this._priority = priority || 0;
+	}
+	
+	SignalBinding.prototype = /** @lends signals.SignalBinding.prototype */ {
+		
+		/**
+		 * If binding is active and should be executed.
+		 * @type boolean
+		 */
+		active : true,
+		
+		/**
+		 * Call listener passing arbitrary parameters.
+		 * <p>If binding was added using `Signal.addOnce()` it will be automatically removed from signal dispatch queue, this method is used internally for the signal dispatch.</p> 
+		 * @param {Array} [paramsArr]	Array of parameters that should be passed to the listener
+		 * @return {*} Value returned by the listener.
+		 */
+		execute : function(paramsArr){
+			var r;
+			if(this.active){
+				r = this._listener.apply(this.context, paramsArr);
+				if(this._isOnce){
+					this.detach();
+				}
+			}
+			return r;
+		},
+		
+		/**
+		 * Detach binding from signal.
+		 * - alias to: mySignal.remove(myBinding.getListener());
+		 * @return {Function} Handler function bound to the signal.
+		 */
+		detach : function(){
+			return this._signal.remove(this._listener);
+		},
+		
+		/**
+		 * @return {Function} Handler function bound to the signal.
+		 */
+		getListener : function(){
+			return this._listener;
+		},
+		
+		/**
+		 * Remove binding from signal and destroy any reference to external Objects (destroy SignalBinding object).
+		 * <p><strong>IMPORTANT:</strong> calling methods on the binding instance after calling dispose will throw errors.</p>
+		 */
+		dispose : function(){
+			this.detach();
+			this._destroy();
+		},
+		
+		/**
+		 * Delete all instance properties
+		 * @private
+		 */
+		_destroy : function(){
+			delete this._signal;
+			delete this._isOnce;
+			delete this._listener;
+			delete this.context;
+		},
+		
+		/**
+		 * @return {boolean} If SignalBinding will only be executed once.
+		 */
+		isOnce : function(){
+			return this._isOnce;
+		},
+		
+		/**
+		 * @return {string} String representation of the object.
+		 */
+		toString : function(){
+			return '[SignalBinding isOnce: '+ this._isOnce +', active: '+ this.active +']';
+		}
+		
+	};
+
+/*global signals:true, SignalBinding:true*/
+	
+	// Signal --------------------------------------------------------
+	//================================================================
+	
+	/**
+	 * Custom event broadcaster
+	 * <br />- inspired by Robert Penner's AS3 Signals.
+	 * @author Miller Medeiros
+	 * @constructor
+	 */
+	signals.Signal = function(){
+		/**
+		 * @type Array.<SignalBinding>
+		 * @private
+		 */
+		this._bindings = [];
+	};
+	
+	signals.Signal.prototype = {
+		
+		/**
+		 * @type boolean
+		 * @private
+		 */
+		_shouldPropagate : true,
+		
+		/**
+		 * If Signal is active and should broadcast events.
+		 * <p><strong>IMPORTANT:</strong> Setting this property during a dispatch will only affect the next dispatch, if you want to stop the propagation of a signal use `halt()` instead.</p>
+		 * @type boolean
+		 */
+		active : true,
+		
+		/**
+		 * @param {Function} listener
+		 * @param {boolean} isOnce
+		 * @param {Object} [scope]
+		 * @param {Number} [priority]
+		 * @return {SignalBinding}
+		 * @private
+		 */
+		_registerListener : function(listener, isOnce, scope, priority){
+			
+			if(typeof listener !== 'function'){
+				throw new Error('listener is a required param of add() and addOnce() and should be a Function.');
+			}
+			
+			var prevIndex = this._indexOfListener(listener),
+				binding;
+			
+			if(prevIndex !== -1){ //avoid creating a new Binding for same listener if already added to list
+				binding = this._bindings[prevIndex];
+				if(binding.isOnce() !== isOnce){
+					throw new Error('You cannot add'+ (isOnce? '' : 'Once') +'() then add'+ (!isOnce? '' : 'Once') +'() the same listener without removing the relationship first.');
+				}
+			} else {
+				binding = new SignalBinding(this, listener, isOnce, scope, priority);
+				this._addBinding(binding);
+			}
+			
+			return binding;
+		},
+		
+		/**
+		 * @param {Function} binding
+		 * @private
+		 */
+		_addBinding : function(binding){
+			//simplified insertion sort
+			var n = this._bindings.length;
+			do { --n; } while (this._bindings[n] && binding._priority <= this._bindings[n]._priority);
+			this._bindings.splice(n+1, 0, binding);
+		},
+		
+		/**
+		 * @param {Function} listener
+		 * @return {number}
+		 * @private
+		 */
+		_indexOfListener : function(listener){
+			var n = this._bindings.length;
+			while(n--){
+				if(this._bindings[n]._listener === listener){
+					return n;
+				}
+			}
+			return -1;
+		},
+		
+		/**
+		 * Add a listener to the signal.
+		 * @param {Function} listener	Signal handler function.
+		 * @param {Object} [scope]	Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+		 * @param {Number} [priority]	The priority level of the event listener. Listeners with higher priority will be executed before listeners with lower priority. Listeners with same priority level will be executed at the same order as they were added. (default = 0)
+		 * @return {SignalBinding} An Object representing the binding between the Signal and listener.
+		 */
+		add : function(listener, scope, priority){
+			return this._registerListener(listener, false, scope, priority);
+		},
+		
+		/**
+		 * Add listener to the signal that should be removed after first execution (will be executed only once).
+		 * @param {Function} listener	Signal handler function.
+		 * @param {Object} [scope]	Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+		 * @param {Number} [priority]	The priority level of the event listener. Listeners with higher priority will be executed before listeners with lower priority. Listeners with same priority level will be executed at the same order as they were added. (default = 0)
+		 * @return {SignalBinding} An Object representing the binding between the Signal and listener.
+		 */
+		addOnce : function(listener, scope, priority){
+			return this._registerListener(listener, true, scope, priority);
+		},
+		
+		/**
+		 * Remove a single listener from the dispatch queue.
+		 * @param {Function} listener	Handler function that should be removed.
+		 * @return {Function} Listener handler function.
+		 */
+		remove : function(listener){
+			if(typeof listener !== 'function'){
+				throw new Error('listener is a required param of remove() and should be a Function.');
+			}
+			
+			var i = this._indexOfListener(listener);
+			if(i !== -1){
+				this._bindings[i]._destroy(); //no reason to a SignalBinding exist if it isn't attached to a signal
+				this._bindings.splice(i, 1);
+			}
+			return listener;
+		},
+		
+		/**
+		 * Remove all listeners from the Signal.
+		 */
+		removeAll : function(){
+			var n = this._bindings.length;
+			while(n--){
+				this._bindings[n]._destroy();
+			}
+			this._bindings.length = 0;
+		},
+		
+		/**
+		 * @return {number} Number of listeners attached to the Signal.
+		 */
+		getNumListeners : function(){
+			return this._bindings.length;
+		},
+		
+		/**
+		 * Stop propagation of the event, blocking the dispatch to next listeners on the queue.
+		 * <p><strong>IMPORTANT:</strong> should be called only during signal dispatch, calling it before/after dispatch won't affect signal broadcast.</p>
+		 * @see signals.Signal.prototype.disable 
+		 */
+		halt : function(){
+			this._shouldPropagate = false;
+		},
+		
+		/**
+		 * Dispatch/Broadcast Signal to all listeners added to the queue. 
+		 * @param {...*} [params]	Parameters that should be passed to each handler.
+		 */
+		dispatch : function(params){
+			if(! this.active){
+				return;
+			}
+			
+			var paramsArr = Array.prototype.slice.call(arguments),
+				bindings = this._bindings.slice(), //clone array in case add/remove items during dispatch
+				n = this._bindings.length;
+			
+			this._shouldPropagate = true; //in case `halt` was called before dispatch or during the previous dispatch.
+			
+			//execute all callbacks until end of the list or until a callback returns `false` or stops propagation
+			//reverse loop since listeners with higher priority will be added at the end of the list
+			do { n--; } while (bindings[n] && this._shouldPropagate && bindings[n].execute(paramsArr) !== false);
+		},
+		
+		/**
+		 * Remove all bindings from signal and destroy any reference to external objects (destroy Signal object).
+		 * <p><strong>IMPORTANT:</strong> calling any method on the signal instance after calling dispose will throw errors.</p>
+		 */
+		dispose : function(){
+			this.removeAll();
+			delete this._bindings;
+		},
+		
+		/**
+		 * @return {string} String representation of the object.
+		 */
+		toString : function(){
+			return '[Signal active: '+ this.active +' numListeners: '+ this.getNumListeners() +']';
+		}
+		
+	};
+
+exports = signals;
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "name"        : "js-signals",
+    "main"        : "dist/js-signals.cjs.js",
+    "description" : "Custom Event/Messaging system for JavaScript inspired by AS3-Signals",
+    "version"     : "0.6",
+    "author"      : "Miller Medeiros (http://blog.millermedeiros.com/)",
+    "repository"  : {
+        "type"    : "git",
+        "url"     : "https://github.com/millermedeiros/js-signals.git"
+    },
+    "homepage"    : "http://millermedeiros.github.com/js-signals/"
+}
+


### PR DESCRIPTION
Hi Miller

Here are some changes that will make it possible to publish the js-signals with NPM. There are a few ways to do this - this proposal involves the smallest amount of change to the existing structure and build that I could think of. NPM expects a tar.gz with a package.json file in the root. This change creates a version of the module in common js format in the dist folder and a package.json meta-data file in the root. With these changes, publishing to NPM would be achieved by running the following after the tag has been pushed to github (once you've set npm up to be able to publish):

```
npm publish https://github.com/millermedeiros/js-signals/tarball/vVERSION
```

Let me know if you can think of a better way to achieve this, or would prefer not to do the publishing to NPM yourself.

Thanks

Tom
