### PR TITLE
Minor Tweak to Signal Binding

### DIFF
--- a/dev/src/SignalBinding.js
+++ b/dev/src/SignalBinding.js
@@ -70,7 +70,7 @@
 		 */
 		execute : function(paramsArr){
 			var r;
-			if(this.active){
+			if(this.active && !!this._listener){
 				r = this._listener.apply(this.context, paramsArr);
 				if(this._isOnce){
 					this.detach();


### PR DESCRIPTION
I was finding that if the SignalBinding was still set to active, but that the signal listener was removed it would execute against an undefined object.

I think it's because in the dispatch loop the binding exists but the actual listener may not. Obviously one may disable the binding but I just added the !!this._listener for safety :)
