### PR TITLE
fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,5 @@
     "directories" : {
         "doc" : "./dist/docs"
     },
-    "licenses" : [
-        {
-            "type" : "MIT",
-            "url" : "http://www.opensource.org/licenses/mit-license.php"
-        }
-    ]
+    "license" : "MIT"
 }


### PR DESCRIPTION
according to the spec, you should use `license` instead of `licenses`
https://docs.npmjs.com/files/package.json#license

Right now this module is getting flagged by our legal tools as having no license.

Cheers!
